### PR TITLE
Fix max_idx+1 out of range

### DIFF
--- a/blind_watermark/recover.py
+++ b/blind_watermark/recover.py
@@ -56,7 +56,7 @@ def search_template(scale=(0.5, 2), search_num=200):
             if score > max_score:
                 max_idx, max_score = idx, score
 
-        min_scale, max_scale = tmp[max(0, max_idx - 1)][2], tmp[max(0, max_idx + 1)][2]
+        min_scale, max_scale = tmp[max(0, max_idx - 1)][2], tmp[min(len(tmp)-1, max_idx + 1)][2]
 
         search_num = 2 * int((max_scale - min_scale) * max(template.shape[1], template.shape[0])) + 1
 


### PR DESCRIPTION
1. It is unnecessary to use `min(0, max_idx)` since max_idx will be always >= 0.
2. `max_idx` may be the last index of the array `tmp`, therefore `max_idx+1` should be restricted.