### PR TITLE
📚 docs(watermark): 更新水印提取文档示例/Updated watermark extraction document example

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ bwm1.embed('output/embedded.png')
 
 Extract:
 ```python
-bwm1 = WaterMark(password_img=1, password_wm=1, wm_shape=6)
-wm_extract = bwm1.extract('output/打上水印的图.png', mode='bit')
+bwm1 = WaterMark(password_img=1, password_wm=1)
+wm_extract = bwm1.extract('output/embedded.png', wm_shape=6, mode='bit')
 print(wm_extract)
 ```
 Notice that `wm_shape` (shape of watermark) is necessary

--- a/README_cn.md
+++ b/README_cn.md
@@ -152,8 +152,8 @@ bwm1.embed('output/打上水印的图.png')
 
 解水印：（注意设定水印形状 `wm_shape`）
 ```python
-bwm1 = WaterMark(password_img=1, password_wm=1, wm_shape=6)
-wm_extract = bwm1.extract('output/打上水印的图.png', mode='bit')
+bwm1 = WaterMark(password_img=1, password_wm=1)
+wm_extract = bwm1.extract('output/打上水印的图.png', wm_shape=6, mode='bit')
 print(wm_extract)
 ```
 


### PR DESCRIPTION
- 修正wm_shape参数说明：文档示例中，将 `wm_shape` 参数的传递方式从 `WaterMark` 类初始化时调整为 `extract` 方法调用时传入，以符合最新代码逻辑
- 更新示例文件名：将英文示例中水印图片的文件名从 `打上水印的图.png` 更新为 `embedded.png`
- Corrected the wm_shape parameter description: In the document example, the `wm_shape` parameter was passed from the `WaterMark` class initialization to the `extract` method call to conform to the latest code logic
- Updated the example file name: Updated the watermark image file name in the English example from `watermarked.png` to `embedded.png`