### PR TITLE
Fix odd-length hex text extraction

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
           python examples/example_no_writing.py
           python examples/example_str.py
           python examples/example_str_multi.py
+          python -m unittest discover -s tests
       #        pytest --cov .
 #      - name: Upload coverage reports to Codecov with GitHub Action
 #        uses: codecov/codecov-action@v3

--- a/blind_watermark/blind_watermark.py
+++ b/blind_watermark/blind_watermark.py
@@ -11,6 +11,14 @@ from .bwm_core import WaterMarkCore
 from .version import bw_notes
 
 
+def _bits_to_text(bits):
+    byte = ''.join(str((i >= 0.5) * 1) for i in bits)
+    hex_str = hex(int(byte, base=2))[2:]
+    if len(hex_str) % 2:
+        hex_str = '0' + hex_str
+    return bytes.fromhex(hex_str).decode('utf-8', errors='replace')
+
+
 class WaterMark:
     def __init__(self, password_wm=1, password_img=1, block_shape=(4, 4), mode='common', processes=None):
         bw_notes.print_notes()
@@ -102,7 +110,6 @@ class WaterMark:
             wm = 255 * wm.reshape(wm_shape[0], wm_shape[1])
             cv2.imwrite(out_wm_name, wm)
         elif mode == 'str':
-            byte = ''.join(str((i >= 0.5) * 1) for i in wm)
-            wm = bytes.fromhex(hex(int(byte, base=2))[2:]).decode('utf-8', errors='replace')
+            wm = _bits_to_text(wm)
 
         return wm

--- a/tests/test_extract_text_decode.py
+++ b/tests/test_extract_text_decode.py
@@ -1,0 +1,20 @@
+import unittest
+
+import numpy as np
+
+from blind_watermark.blind_watermark import WaterMark
+
+
+class ExtractTextDecodeTest(unittest.TestCase):
+    def test_extract_str_pads_odd_length_hex(self):
+        bwm = WaterMark(password_img=1, password_wm=1)
+        bwm.extract_decrypt = lambda wm_avg: wm_avg
+        bwm.bwm_core.extract_with_kmeans = lambda img, wm_shape: np.array([1, 1, 1, 1])
+
+        wm = bwm.extract(embed_img=np.zeros((4, 4, 3)), wm_shape=4, mode='str')
+
+        self.assertEqual(wm, '\x0f')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #176.

## Summary
- Pad odd-length hex strings before `bytes.fromhex()` in string watermark extraction.
- Keep the existing `errors="replace"` decode behavior, so attacked/cropped images may still decode to replacement text instead of claiming recovery.
- Add a unittest regression case for the odd-length hex path and run it in GitHub Actions.

## Tests
- `python -m unittest discover -s tests`
- `python setup.py install`
- `python examples/example_bit.py`
- `python examples/example_img.py`
- `python examples/example_no_writing.py`
- `python examples/example_str.py`
- `python examples/example_str_multi.py`
- `git diff --check`